### PR TITLE
Bumps AWS provider version to enable updated features

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    aws    = ">= 2.55"
+    aws    = ">= 3.23"
     random = ">= 2.1"
   }
 }


### PR DESCRIPTION
As seen in https://github.com/hashicorp/terraform-provider-aws/issues/16866, the following feature is not available in AWS providers older than v3.23:

```terraform
resource "aws_msk_cluster" "kafka_cluster" {
...
enhanced_monitoring = "PER_TOPIC_PER_PARTITION"
...
}
```

`PER_TOPIC_PER_PARTITION` is a valid config for enhanced monitoring (https://docs.aws.amazon.com/msk/latest/developerguide/metrics-details.html#topic-partition-metrics), but it has been included in AWS Terraform Provider v3.23.

If one attempts to set `PER_TOPIC_PER_PARTITION` with the current version constraints, the following is shown:

```sh
Error: expected enhanced_monitoring to be one of [DEFAULT PER_BROKER PER_TOPIC_PER_BROKER], got PER_TOPIC_PER_PARTITION
```

This pull request bumps the provider version to enable `PER_TOPIC_PER_PARTITION` monitoring in MSK clusters.