### PR TITLE
fix: Support in-place kafka version upgrades

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -75,6 +75,7 @@ resource "random_id" "configuration" {
 
   keepers = {
     server_properties = local.server_properties
+    kafka_version     = var.kafka_version
   }
 }
 


### PR DESCRIPTION
fixes #10

This small change ensures that a new msk configuration is created with a
new name that doesn't collide with the previous name, allowing in-place MSK cluster upgrades.