### PR TITLE
feat: Add outputs for bootstrap brokers if SASL access is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,13 @@ No modules.
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | Amazon Resource Name (ARN) of the MSK cluster. |
 | <a name="output_bootstrap_brokers"></a> [bootstrap\_brokers](#output\_bootstrap\_brokers) | A comma separated list of one or more hostname:port pairs of kafka brokers suitable to boostrap connectivity to the kafka cluster. Only contains value if client\_broker encryption in transit is set o PLAINTEXT or TLS\_PLAINTEXT. |
+| <a name="output_bootstrap_brokers_sasl_iam"></a> [bootstrap\_brokers\_sasl\_iam](#output\_bootstrap\_brokers\_sasl\_iam) | A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity to the kafka cluster. Only contains value if client\_broker encryption in transit is set to SASL IAM. |
+| <a name="output_bootstrap_brokers_sasl_scram"></a> [bootstrap\_brokers\_sasl\_scram](#output\_bootstrap\_brokers\_sasl\_scram) | A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity to the kafka cluster. Only contains value if client\_broker encryption in transit is set to SASL SCRAM. |
 | <a name="output_bootstrap_brokers_tls"></a> [bootstrap\_brokers\_tls](#output\_bootstrap\_brokers\_tls) | A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity to the kafka cluster. Only contains value if client\_broker encryption in transit is set to TLS\_PLAINTEXT or TLS. |
 | <a name="output_current_version"></a> [current\_version](#output\_current\_version) | Current version of the MSK Cluster used for updates, e.g. K13V1IB3VIYZZH |
 | <a name="output_default_security_group"></a> [default\_security\_group](#output\_default\_security\_group) | Msk cluster default security group id. |
 | <a name="output_encryption_at_rest_kms_key_arn"></a> [encryption\_at\_rest\_kms\_key\_arn](#output\_encryption\_at\_rest\_kms\_key\_arn) | The ARN of the KMS key used for encryption at rest of the broker data volumes. |
+| <a name="output_extra_security_groups"></a> [extra\_security\_groups](#output\_extra\_security\_groups) | Msk cluster extra security group ids. |
 | <a name="output_zookeeper_connect_string"></a> [zookeeper\_connect\_string](#output\_zookeeper\_connect\_string) | A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "default_security_group" {
   value       = aws_security_group.this.id
 }
 
+output "extra_security_groups" {
+  description = "Msk cluster extra security group ids."
+  value       = var.extra_security_groups
+}
+
 output "arn" {
   description = "Amazon Resource Name (ARN) of the MSK cluster."
   value       = aws_msk_cluster.this.arn
@@ -16,6 +21,16 @@ output "bootstrap_brokers" {
 output "bootstrap_brokers_tls" {
   description = "A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity to the kafka cluster. Only contains value if client_broker encryption in transit is set to TLS_PLAINTEXT or TLS."
   value       = aws_msk_cluster.this.bootstrap_brokers_tls
+}
+
+output "bootstrap_brokers_sasl_scram" {
+  description = "A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity to the kafka cluster. Only contains value if client_broker encryption in transit is set to SASL SCRAM."
+  value       = aws_msk_cluster.this.bootstrap_brokers_sasl_scram
+}
+
+output "bootstrap_brokers_sasl_iam" {
+  description = "A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity to the kafka cluster. Only contains value if client_broker encryption in transit is set to SASL IAM."
+  value       = aws_msk_cluster.this.bootstrap_brokers_sasl_iam
 }
 
 output "current_version" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,12 +25,12 @@ output "bootstrap_brokers_tls" {
 
 output "bootstrap_brokers_sasl_scram" {
   description = "A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity to the kafka cluster. Only contains value if client_broker encryption in transit is set to SASL SCRAM."
-  value       = aws_msk_cluster.this.bootstrap_brokers_sasl_scram
+  value       = aws_msk_cluster.this.bootstrap_brokers_sasl_scram != "" ? aws_msk_cluster.this.bootstrap_brokers_sasl_scram : null
 }
 
 output "bootstrap_brokers_sasl_iam" {
   description = "A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity to the kafka cluster. Only contains value if client_broker encryption in transit is set to SASL IAM."
-  value       = aws_msk_cluster.this.bootstrap_brokers_sasl_iam
+  value       = aws_msk_cluster.this.bootstrap_brokers_sasl_iam != "" ? aws_msk_cluster.this.bootstrap_brokers_sasl_iam : null
 }
 
 output "current_version" {


### PR DESCRIPTION
This PR simply adds some extra outputs to be used by the calling module. Fee free to add any comemtns.

Thanks!