### PR TITLE
improvement: made provisioned_throughput block optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -123,9 +123,12 @@ resource "aws_msk_cluster" "this" {
         volume_size = var.volume_size
 
 
-        provisioned_throughput {
-          enabled           = var.provisioned_volume_throughput == null ? false : true
-          volume_throughput = var.provisioned_volume_throughput
+       dynamic "provisioned_throughput" {
+          for_each = var.provisioned_volume_throughput[*]
+          content {
+            enabled           = true
+            volume_throughput = var.provisioned_volume_throughput
+          }
         }
       }
     }


### PR DESCRIPTION
This PR is making provisioned_throughput block optional in case variable `provisioned_volume_throughput` is not specified.
We run into the issue where module is constantly reporting this change
` provisioned_throughput {
                      enabled           = false
}`
 in terraform state since we did not specify `provisioned_volume_throughput` variable.
 
If variable is not specified, provisioned_throughput block should not be initialized.

Do yo think this PR could be merged?
Please feel free to add any comments.

Thanks in advance!
