### PR TITLE
Added lifecycle to ignore null changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -193,6 +193,11 @@ resource "aws_msk_cluster" "this" {
       }
     }
   }
-
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to provisioned_throughput to avoid errors
+      broker_node_group_info[0].storage_info[0].ebs_storage_info[0].provisioned_throughput,
+    ]
+  }
   tags = var.tags
 }


### PR DESCRIPTION
**what**
Fix for issues with cluster config edit (terraform always wants to change provisioned_throughput config as follows)

**why**
~ resource "aws_msk_cluster" "default" {
      id                           = "arn:aws:kafka:eu-central-1:0000000:cluster/kafka/"
      # (12 unchanged attributes hidden)

      ~ broker_node_group_info {
            # (4 unchanged attributes hidden)

          ~ storage_info {
              ~ ebs_storage_info {
                    # (1 unchanged attribute hidden)

                  - provisioned_throughput {
                      - enabled           = false -> null
                      - volume_throughput = 0 -> null
                    }
                }
            }

          # (1 unchanged block hidden)
      }

      # (5 unchanged blocks hidden)
  }
This leads to following error:

 Error: updating MSK Cluster (arn:aws:kafka:eu-central-1:00000:cluster/kafka/) security: BadRequestException: The request does not include any updates to the security setting of the cluster. Verify the request, then try again.
│ {
│   RespMetadata: {
│     StatusCode: 400,
│     RequestID: "1d43c33f-6f0e-4ad7-b25f-17130137ccd2"
│   },
│   Message_: "BadRequestException: The request does not include any updates to the EBS volumes of the cluster. Verify the request, then try again."
│ }
